### PR TITLE
fix(docs): Top nav left alignment

### DIFF
--- a/gatsby-theme-patternfly-org/components/topNav.css
+++ b/gatsby-theme-patternfly-org/components/topNav.css
@@ -1,3 +1,9 @@
+@media (min-width: 992px) {
+  .ws-top-nav {
+    margin-left: -20px;
+  }
+}
+
 .ws-top-nav.pf-c-nav__horizontal-list .pf-c-nav__link {
   padding-top: 22px;
   padding-right: var(--pf-global--spacer--md);


### PR DESCRIPTION
Moved topnav left on desktop to align hover state with left nav background